### PR TITLE
Applied monkey patch

### DIFF
--- a/currencylayer.gemspec
+++ b/currencylayer.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "currencylayer"
-  spec.version       = '0.0.1'
+  spec.version       = '0.0.2'
   spec.authors       = ["Andrey Skuratovsky"]
   spec.email         = ["skuratowsky@gmail.com"]
   spec.summary       = "Access to the currencylayer.com online exchange rates"

--- a/currencylayer.gemspec
+++ b/currencylayer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         =  Dir.glob("{lib,spec}/**/*")
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "money", "~> 6"
+  spec.add_dependency "money", "~> 6.13.1"
 
   spec.add_development_dependency "rspec", ">= 3.0.0"
   spec.add_development_dependency "timecop"

--- a/lib/money/bank/currencylayer.rb
+++ b/lib/money/bank/currencylayer.rb
@@ -1,5 +1,6 @@
 require 'money'
 require 'open-uri'
+require_relative 'on_time_patch'
 
 # Money class, see http://github.com/RubyMoney/money
 class Money
@@ -7,7 +8,6 @@ class Money
   # Provides classes that aid in the ability of exchange one currency with
   # another.
   module Bank
-
     # Exception that will be thrown if jsonrates.com api returns error on api request.
     class RequestError < StandardError ; end
 
@@ -21,6 +21,7 @@ class Money
 
     # Money::Bank implementation that gives access to the current exchange rates using jsonrates.com api.
     class Currencylayer < Money::Bank::VariableExchange
+      include OnTimePatch
 
       # Host of service jsonrates
       SERVICE_HOST = "apilayer.net"

--- a/lib/money/bank/on_time_patch.rb
+++ b/lib/money/bank/on_time_patch.rb
@@ -1,0 +1,17 @@
+module OnTimePatch
+  def find_rate_for_date(from, to, date)
+    date = Date.today unless date.respond_to?(:strftime)
+
+    formated_date = date.strftime('%Y-%m-%d')
+
+    # The only difference is here, as we should also send
+    # the specific date query param
+    uri = build_uri(from, to)
+    uri.query = "#{uri.query}&date=#{formated_date}"
+
+    data = perform_request(uri)
+    rate = extract_rate(data, from, to)
+
+    add_rate(from, to, rate)
+  end
+end

--- a/spec/currencylayer_spec.rb
+++ b/spec/currencylayer_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe "Currencylayer" do
+  let(:bank) { Money::Bank::Currencylayer.new }
+
   before :each do
-    @bank = Money::Bank::Currencylayer.new
-    @bank.access_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    bank.access_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+
+    Money::Bank::Currencylayer.rates_careful = false
+    Money::Bank::Currencylayer.ttl_in_seconds = 86400
   end
 
   it "should accept a ttl_in_seconds option" do
@@ -13,40 +17,42 @@ describe "Currencylayer" do
 
   describe '.get_rate' do
     it 'returns rate' do
-      uri = @bank.send(:build_uri, 'USD', 'EUR').to_s
+      uri = bank.send(:build_uri, 'USD', 'EUR').to_s
       stub_request(:get, uri).to_return( :status => 200,
         :body => '{"success":true,"terms":"https:\/\/currencylayer.com\/terms","privacy":"https:\/\/currencylayer.com\/privacy","timestamp":1434443053,"source":"USD","quotes":{"USDEUR":0.887701}}')
 
-      @bank.flush_rates
-      rate = @bank.get_rate('USD', 'EUR')
+      bank.flush_rates
+
+      rate = bank.get_rate('USD', 'EUR')
+
       expect(rate).to eq(BigDecimal.new("0.887701"))
     end
+
     context "in careful mode" do
-
-      it "don't flush rate if get some exception on request" do
-
+      before do
         Money::Bank::Currencylayer.rates_careful = true
         Money::Bank::Currencylayer.ttl_in_seconds = 0
+      end
 
-        @bank.flush_rates
-        @bank.add_rate('USD', 'EUR', 1.011)
+      it "don't flush rate if get some exception on request" do
+        bank.flush_rates
+        bank.add_rate('USD', 'EUR', 1.011)
 
-
-        uri = @bank.send(:build_uri, 'USD', 'EUR').to_s
+        uri = bank.send(:build_uri, 'USD', 'EUR').to_s
 
         stub_request(:get, uri).to_return(:status => 200, :body => '{"success":false,"error":{"code":202,"info":"You have provided one or more invalid Currency Codes. [Required format: currencies=EUR,USD,GBP,...]"}}')
-        rate = @bank.get_rate('USD', 'EUR')
+
+        rate = bank.get_rate('USD', 'EUR')
+
         expect(rate).to eq(BigDecimal.new("1.011"))
 
         Money::Bank::Currencylayer.rates_careful = false
       end
-
     end
   end
 
   describe ".refresh_rates_expiration!" do
     it "set the .rates_expiration using the TTL and the current time" do
-      Money::Bank::Currencylayer.ttl_in_seconds = 86400
       new_time = Time.now
       Timecop.freeze(new_time)
       Money::Bank::Currencylayer.refresh_rates_expiration!
@@ -56,28 +62,29 @@ describe "Currencylayer" do
 
   describe ".flush_rates" do
     it "should empty @rates" do
-      @bank.add_rate("USD", "CAD", 1.24515)
-      @bank.flush_rates
-      expect(@bank.rates).to eq({})
+      bank.add_rate("USD", "CAD", 1.24515)
+      bank.flush_rates
+      expect(bank.rates).to eq({})
     end
   end
 
   describe 'careful mode' do
     it 'returns cached value if exception raised' do
-      @bank.flush_rates
-      @bank.add_rate("USD", "CAD", 32.231)
-      expect(@bank.get_rate("USD", "CAD")).to eq (BigDecimal.new('32.231'))
+      bank.flush_rates
+      bank.add_rate("USD", "CAD", 32.231)
+      expect(bank.get_rate("USD", "CAD")).to eq (BigDecimal.new('32.231'))
     end
   end
 
   describe ".flush_rate" do
     it "should remove a specific rate from @rates" do
-      @bank.flush_rates
-      @bank.add_rate('USD', 'EUR', 1.4)
-      @bank.add_rate('USD', 'JPY', 0.3)
-      @bank.flush_rate('USD', 'EUR')
-      expect(@bank.rates).to include('USD_TO_JPY')
-      expect(@bank.rates).to_not include('USD_TO_EUR')
+      bank.flush_rates
+      bank.add_rate('USD', 'EUR', 1.4)
+      bank.add_rate('USD', 'JPY', 0.3)
+      bank.flush_rate('USD', 'EUR')
+
+      expect(bank.rates).to include('USD_TO_JPY')
+      expect(bank.rates).to_not include('USD_TO_EUR')
     end
   end
 
@@ -93,22 +100,22 @@ describe "Currencylayer" do
       end
 
       it "should flush all rates" do
-        expect(@bank).to receive(:flush_rates)
-        @bank.expire_rates
+        expect(bank).to receive(:flush_rates)
+        bank.expire_rates
       end
 
       it "updates the next expiration time" do
         exp_time = Time.now + 1000
 
-        @bank.expire_rates
+        bank.expire_rates
         expect(Money::Bank::Currencylayer.rates_expiration).to eq(exp_time)
       end
     end
 
     context "when the ttl has not expired" do
       it "not should flush all rates" do
-        expect(@bank).to_not receive(:flush_rates)
-        @bank.expire_rates
+        expect(bank).to_not receive(:flush_rates)
+        bank.expire_rates
       end
     end
   end


### PR DESCRIPTION
## What does this PR do?
This pull-request adds the MonkeyPatch from `streetbees-api` directly into the `currencylayer` gem, as well as making the code compatible with the `money` gem on version 6.13.1.

The internal structure of money changed completely since the 6.6 version.
The currencylayer added some sort of caching into the layer and I've tried to preserve this as much as possible. `currencylayer` now relies on the same internal structure that money does, but still uses it's own caching logic where possible.

## Where should the reviewer start?
spec file to understand how `currencylayer` is supposed to work.

## How should this be manually tested?
Will be tested through usage in `streetbees-api`

## Related PRs
https://github.com/Streetbees/streetbees-api/pull/1689

## Trello cards

## Screenshots

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)